### PR TITLE
Don't crash if a key value pair fails to parse

### DIFF
--- a/rs/crates/rq-core/src/command.rs
+++ b/rs/crates/rq-core/src/command.rs
@@ -12,13 +12,14 @@ fn get_user_env() -> HashMap<String, String> {
     .output()
     .expect("Failed to get shell env");
   let stdout = String::from_utf8(output.stdout).expect("Env vars not utf8");
-  stdout
-    .lines()
-    .map(|line| {
-      let (key, value) = line.split_once("=").expect("Failed to parse env k/v");
-      (key.to_string(), value.to_string())
-    })
-    .collect()
+  let mut key_vals: HashMap <String,String> = HashMap::new();
+  for line in stdout.lines() {
+    // If a key-value pair can be parsed we insert it, else we move on
+    if let Some((key, value)) = line.split_once("=") {
+      key_vals.insert(key.to_string(), value.to_string());
+    }
+  }
+  key_vals
 }
 
 static ENV: LazyLock<HashMap<String, String>> = LazyLock::new(|| {


### PR DESCRIPTION
For some reason some of the values in my environment look like this:
```
NDK_HOME=/home/scp5761/Android/Sdk/ndk/27.0.12077973
28.0.12433566
28.0.12674087
```
this may or may not be a valid environment key value pair but regardless the program should just skip those two lines when parsing environment variables rather than crash.