### PR TITLE
Check whether the publickey error message occurs anywhere in stderr

### DIFF
--- a/rs/crates/rq-core/src/github.rs
+++ b/rs/crates/rq-core/src/github.rs
@@ -92,7 +92,7 @@ pub fn check_ssh() -> Result<()> {
     Some(1) => Ok(()),
     _ => {
       let stderr = String::from_utf8(output.stderr)?;
-      if stderr.trim() == "git@github.com: Permission denied (publickey)." {
+      if stderr.contains("git@github.com: Permission denied (publickey).") {
         bail!("Your machine is not setup for a secure connection to Github. Please follow the instructions here: https://docs.github.com/en/authentication/troubleshooting-ssh/error-permission-denied-publickey");
       } else {
         bail!("Failed to establish a secure connection to Github with error:\n{stderr}")


### PR DESCRIPTION
If a user has not registered `github.com`'s fingerprint on ssh
(this can be simulated by deleting it from `~/.ssh/known_hosts` if it was already registered)

Then the error message looks like this:
![repo_q](https://github.com/user-attachments/assets/3f537a7a-f2bc-4795-931e-154a3e12adf4)
Instead of the intended error message.